### PR TITLE
AA-8: Remove JIRA valdiation for main

### DIFF
--- a/.github/workflows/jira-issue-key-check.yml
+++ b/.github/workflows/jira-issue-key-check.yml
@@ -28,9 +28,11 @@ jobs:
           fi
 
       - name: Fetch base branch
+        if: ${{ github.head_ref != 'main' && github.head_ref != 'Validation-Branch' && github.head_ref != 'production' }}
         run: git fetch origin ${{ github.base_ref }}
 
       - name: Get commit messages
+        if: ${{ github.head_ref != 'main' && github.head_ref != 'Validation-Branch' && github.head_ref != 'production' }}
         id: commits
         run: |
           commits=$(git log origin/${{ github.base_ref }}..HEAD --pretty=format:"%s")
@@ -39,6 +41,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Validate commit messages
+        if: ${{ github.head_ref != 'main' && github.head_ref != 'Validation-Branch' && github.head_ref != 'production' }}
         run: |
           echo "🔍 Validating commit messages contain AA-<number> keys"
           while read -r msg; do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to skip certain validation steps on 'main', 'Validation-Branch', and 'production' branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->